### PR TITLE
feat: 재료ID기반 칵테일 배열 반환

### DIFF
--- a/src/main/java/com/shake_match/alchomist/cocktail/domain/CocktailIngredient.java
+++ b/src/main/java/com/shake_match/alchomist/cocktail/domain/CocktailIngredient.java
@@ -1,0 +1,39 @@
+package com.shake_match.alchomist.cocktail.domain;
+
+import com.shake_match.alchomist.ingredient.Ingredient;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+@Table(name = "cocktail_ingredient")
+@Entity
+public class CocktailIngredient {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "cocktail_id")
+    private Cocktail cocktail;
+
+    @ManyToOne
+    @JoinColumn(name = "ingredient_id")
+    private Ingredient ingredient;
+
+    public CocktailIngredient(Cocktail cocktail,
+                              Ingredient ingredient) {
+        this.cocktail = cocktail;
+        this.ingredient = ingredient;
+    }
+}

--- a/src/main/java/com/shake_match/alchomist/cocktail/dto/CocktailSimpleListResponse.java
+++ b/src/main/java/com/shake_match/alchomist/cocktail/dto/CocktailSimpleListResponse.java
@@ -1,0 +1,15 @@
+package com.shake_match.alchomist.cocktail.dto;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class CocktailSimpleListResponse {
+
+    private List<CocktailSimpleResponse> cocktails;
+
+    public CocktailSimpleListResponse(
+        List<CocktailSimpleResponse> cocktails) {
+        this.cocktails = cocktails;
+    }
+}

--- a/src/main/java/com/shake_match/alchomist/cocktail/dto/CocktailSimpleResponse.java
+++ b/src/main/java/com/shake_match/alchomist/cocktail/dto/CocktailSimpleResponse.java
@@ -1,0 +1,41 @@
+package com.shake_match.alchomist.cocktail.dto;
+
+import com.shake_match.alchomist.cocktail.domain.Cocktail;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class CocktailSimpleResponse {
+
+    Long id;
+
+    String name;
+
+    String recipe;
+
+    String type;
+
+    int likes;
+
+    float totalRating;
+
+    public CocktailSimpleResponse(Long id, String name, String recipe, String type, int likes,
+                                  float totalRating) {
+        this.id = id;
+        this.name = name;
+        this.recipe = recipe;
+        this.type = type;
+        this.likes = likes;
+        this.totalRating = totalRating;
+    }
+
+    public CocktailSimpleResponse(Cocktail cocktail) {
+        this.id = cocktail.getId();
+        this.name = cocktail.getName();
+        this.recipe = cocktail.getRecipe();
+        this.type = cocktail.getType();
+        this.likes = cocktail.getLikes();
+        this.totalRating = cocktail.getTotalRating();
+    }
+}

--- a/src/main/java/com/shake_match/alchomist/cocktail/repository/CocktailRepository.java
+++ b/src/main/java/com/shake_match/alchomist/cocktail/repository/CocktailRepository.java
@@ -1,6 +1,7 @@
 package com.shake_match.alchomist.cocktail.repository;
 
 import com.shake_match.alchomist.cocktail.domain.Cocktail;
+import com.shake_match.alchomist.cocktail.domain.CocktailIngredient;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,4 +15,9 @@ public interface CocktailRepository extends JpaRepository<Cocktail, Long> {
 
     @Query("SELECT distinct c FROM cocktails c LEFT JOIN FETCH c.themes t WHERE t.mainCategory=:mainCategory AND t.subCategory=:subCategory")
     List<Cocktail> findByTheme(@Param("mainCategory") String mainCategory, @Param("subCategory") String subCategory);
+
+    @Query("SELECT distinct ci FROM CocktailIngredient ci"
+        + " JOIN FETCH ci.cocktail c"
+        + " WHERE ci.ingredient.id IN :ingredientIds")
+    List<CocktailIngredient> findAllByIngredients(@Param("ingredientIds") List<Long> ingredientIds);
 }

--- a/src/main/java/com/shake_match/alchomist/ingredient/Ingredient.java
+++ b/src/main/java/com/shake_match/alchomist/ingredient/Ingredient.java
@@ -1,6 +1,7 @@
 package com.shake_match.alchomist.ingredient;
 
 import com.shake_match.alchomist.cocktail.domain.Cocktail;
+import com.shake_match.alchomist.cocktail.domain.CocktailIngredient;
 import com.shake_match.alchomist.global.BaseEntity;
 import com.shake_match.alchomist.ingredient.dto.request.IngredientUpdateRequest;
 import lombok.*;
@@ -35,19 +36,13 @@ public class Ingredient extends BaseEntity {
     @Column(name = "measure")
     private String measure;
 
-    @OneToMany(fetch = FetchType.EAGER)
-    private List<Cocktail> cocktails = new ArrayList<>();
+    @OneToMany(mappedBy = "ingredient")
+    private List<CocktailIngredient> cocktailIngredients = new ArrayList<>();
 
     public void update(IngredientUpdateRequest request) {
         this.name = request.getIngredientName();
-        this.cocktails = request.getCocktails();
         this.type = request.getType();
         this.isAlcohol = request.isAlcohol();
         this.measure = request.getMeasure();
     }
-
-    public void addCocktail(Cocktail cocktail) {
-        this.cocktails.add(cocktail);
-    }
-
 }

--- a/src/main/java/com/shake_match/alchomist/ingredient/converter/IngredientConverter.java
+++ b/src/main/java/com/shake_match/alchomist/ingredient/converter/IngredientConverter.java
@@ -2,8 +2,8 @@ package com.shake_match.alchomist.ingredient.converter;
 
 import com.shake_match.alchomist.ingredient.Ingredient;
 import com.shake_match.alchomist.ingredient.dto.request.IngredientDetailRequest;
-import com.shake_match.alchomist.ingredient.dto.response.IngredientListResponse;
 import com.shake_match.alchomist.ingredient.dto.response.IngredientResponse;
+import com.shake_match.alchomist.ingredient.dto.response.IngredientListResponse;
 import com.shake_match.alchomist.ingredient.dto.response.IngredientToListResponse;
 import java.util.List;
 import org.springframework.stereotype.Component;
@@ -28,8 +28,7 @@ public class IngredientConverter {
 
     public IngredientListResponse converterIngredientListResponse(Ingredient ingredient) {
         return new IngredientListResponse(ingredient.getId(), ingredient.getName(),
-            ingredient.getType(), ingredient.isAlcohol(), ingredient.getMeasure(),
-            ingredient.getCocktails());
+            ingredient.getType(), ingredient.isAlcohol(), ingredient.getMeasure());
     }
 
     public IngredientToListResponse converterIngredientToListResponse(

--- a/src/main/java/com/shake_match/alchomist/ingredient/converter/IngredientConverter.java
+++ b/src/main/java/com/shake_match/alchomist/ingredient/converter/IngredientConverter.java
@@ -14,7 +14,6 @@ public class IngredientConverter {
     public Ingredient converterIngredient(IngredientDetailRequest request) { // dto -> entity
         return Ingredient.builder()
                 .name(request.getIngredientName())
-                .cocktails(request.getCocktails())
                 .isAlcohol(request.isAlcohol())
                 .type(request.getType())
                 .measure(request.getMeasure())

--- a/src/main/java/com/shake_match/alchomist/ingredient/dto/request/IngredientUpdateRequest.java
+++ b/src/main/java/com/shake_match/alchomist/ingredient/dto/request/IngredientUpdateRequest.java
@@ -9,7 +9,6 @@ import java.util.List;
 public class IngredientUpdateRequest {
 
     private String ingredientName;
-    private List<Cocktail> cocktails;
     private String type;
     private boolean isAlcohol;
     private String measure;

--- a/src/main/java/com/shake_match/alchomist/ingredient/dto/response/IngredientDetailResponse.java
+++ b/src/main/java/com/shake_match/alchomist/ingredient/dto/response/IngredientDetailResponse.java
@@ -1,10 +1,10 @@
 package com.shake_match.alchomist.ingredient.dto.response;
 
-import com.shake_match.alchomist.cocktail.domain.Cocktail;
 import com.shake_match.alchomist.ingredient.Ingredient;
-import lombok.*;
-
-import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Builder
 @Getter
@@ -14,7 +14,6 @@ public class IngredientDetailResponse {
 
     private Long ingredientId;
     private String ingredientName;
-    private List<Cocktail> cocktails;
     private String type;
     private boolean isAlcohol;
     private String measure;
@@ -22,7 +21,6 @@ public class IngredientDetailResponse {
     public IngredientDetailResponse(Ingredient ingredient) {
         this.ingredientId = ingredient.getId();
         this.ingredientName = ingredient.getName();
-        this.cocktails = ingredient.getCocktails();
         this.type = ingredient.getType();
         this.measure = ingredient.getMeasure();
         this.isAlcohol = ingredient.isAlcohol();

--- a/src/main/java/com/shake_match/alchomist/ingredient/dto/response/IngredientListResponse.java
+++ b/src/main/java/com/shake_match/alchomist/ingredient/dto/response/IngredientListResponse.java
@@ -1,8 +1,5 @@
 package com.shake_match.alchomist.ingredient.dto.response;
 
-import com.shake_match.alchomist.cocktail.domain.Cocktail;
-import java.util.ArrayList;
-import java.util.List;
 import lombok.Getter;
 
 @Getter
@@ -13,16 +10,13 @@ public class IngredientListResponse {
     private final String type;
     private final boolean isAlcohol;
     private final String measure;
-    private List<Cocktail> cocktails = new ArrayList<>();
 
     public IngredientListResponse(Long id, String name, String type, boolean isAlcohol,
-                                  String measure,
-                                  List<Cocktail> cocktails) {
+                                  String measure) {
         this.id = id;
         this.name = name;
         this.type = type;
         this.isAlcohol = isAlcohol;
         this.measure = measure;
-        this.cocktails = cocktails;
     }
 }

--- a/src/main/java/com/shake_match/alchomist/ingredient/dto/response/IngredientUpdateResponse.java
+++ b/src/main/java/com/shake_match/alchomist/ingredient/dto/response/IngredientUpdateResponse.java
@@ -12,14 +12,12 @@ import java.util.List;
 public class IngredientUpdateResponse {
 
     private String ingredientName;
-    private List<Cocktail> cocktails;
     private String type;
     private boolean isAlcohol;
     private String measure;
 
     public IngredientUpdateResponse(Ingredient ingredient) {
         this.ingredientName = ingredient.getName();
-        this.cocktails = ingredient.getCocktails();
         this.type = ingredient.getType();
         this.isAlcohol = ingredient.isAlcohol();
         this.measure = ingredient.getMeasure();

--- a/src/main/java/com/shake_match/alchomist/ingredient/dto/response/IngredientUpdateResponse.java
+++ b/src/main/java/com/shake_match/alchomist/ingredient/dto/response/IngredientUpdateResponse.java
@@ -1,11 +1,8 @@
 package com.shake_match.alchomist.ingredient.dto.response;
 
-import com.shake_match.alchomist.cocktail.domain.Cocktail;
 import com.shake_match.alchomist.ingredient.Ingredient;
 import lombok.Getter;
 import lombok.Setter;
-
-import java.util.List;
 
 @Getter
 @Setter

--- a/src/main/java/com/shake_match/alchomist/users/controller/UserController.java
+++ b/src/main/java/com/shake_match/alchomist/users/controller/UserController.java
@@ -1,20 +1,16 @@
 package com.shake_match.alchomist.users.controller;
 
+import com.shake_match.alchomist.cocktail.dto.CocktailSimpleListResponse;
 import com.shake_match.alchomist.global.ApiResponse;
-import com.shake_match.alchomist.jwt.JwtAuthentication;
-import com.shake_match.alchomist.users.converter.UserConverter;
-import com.shake_match.alchomist.users.dto.response.UserDetailResponse;
 import com.shake_match.alchomist.ingredient.dto.response.IngredientToListResponse;
+import com.shake_match.alchomist.users.converter.UserConverter;
 import com.shake_match.alchomist.users.dto.request.UserBookmarkRequest;
-import com.shake_match.alchomist.users.dto.request.UserRequest;
 import com.shake_match.alchomist.users.dto.request.UserUpdateRequest;
-import com.shake_match.alchomist.users.dto.response.UserBookmarkResponse;
+import com.shake_match.alchomist.users.dto.response.UserDetailResponse;
 import com.shake_match.alchomist.users.dto.response.UserLikeResponse;
 import com.shake_match.alchomist.users.dto.response.UserNicknameResponse;
 import com.shake_match.alchomist.users.service.UserService;
-import javax.validation.Valid;
 import java.util.List;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -29,11 +25,9 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserController {
 
     private final UserService userService;
-    private final UserConverter converter;
 
-    public UserController(UserService userService, UserConverter converter) {
+    public UserController(UserService userService) {
         this.userService = userService;
-        this.converter = converter;
     }
 
     @PutMapping("/info/{userId}") // 회원정보 수정
@@ -52,16 +46,16 @@ public class UserController {
 
     @GetMapping("/nickname/{nickname}") // 닉네임 검색
     public ApiResponse<UserNicknameResponse> findUserByNickname(
-            @PathVariable("nickname") String nickname) {
+        @PathVariable("nickname") String nickname) {
         UserNicknameResponse userNicknameResponse = userService.getUserByNickname(nickname);
         return ApiResponse.ok(userNicknameResponse);
     }
 
     @PostMapping("/bookmark") // 북마크 추가
     public ApiResponse<UserLikeResponse> addUserBookmark(
-            @RequestBody UserBookmarkRequest userBookmarkRequest) {
+        @RequestBody UserBookmarkRequest userBookmarkRequest) {
         UserLikeResponse userLikeResponse = userService.addBookmark(userBookmarkRequest.getUserId(),
-                userBookmarkRequest.getCocktailId());
+            userBookmarkRequest.getCocktailId());
         return ApiResponse.ok(userLikeResponse);
     }
 
@@ -71,12 +65,22 @@ public class UserController {
         userService.deleteBookmark(userBookmarkRequest);
         return ApiResponse.ok("bookmark Deleted successfully");
     }
+
     // 내 술장고 재료조회
     @GetMapping("/ingredient/{userId}")
     public ApiResponse<IngredientToListResponse> findUserByIngredient(
         @PathVariable("userId") Long id) {
         IngredientToListResponse userByIngredient = userService.getUserByIngredient(id);
         return ApiResponse.ok(userByIngredient);
+    }
+
+    // 내 술장고 재료 조회해서 칵테일 배열로 반환
+    @GetMapping("/ingredient")
+    public ApiResponse<CocktailSimpleListResponse> getAllCocktailByIngredients(
+        @RequestBody List<Long> ingredientIds) {
+        CocktailSimpleListResponse allCocktailByIngredient = userService.getAllCocktailByIngredient(
+            ingredientIds);
+        return ApiResponse.ok(allCocktailByIngredient);
     }
 
     @PostMapping("/ingredient/{userId}")

--- a/src/main/java/com/shake_match/alchomist/users/converter/UserConverter.java
+++ b/src/main/java/com/shake_match/alchomist/users/converter/UserConverter.java
@@ -5,7 +5,6 @@ import com.shake_match.alchomist.ingredient.converter.IngredientConverter;
 import com.shake_match.alchomist.ingredient.dto.response.IngredientResponse;
 import com.shake_match.alchomist.users.Users;
 import com.shake_match.alchomist.users.UsersIngredient;
-import com.shake_match.alchomist.users.dto.request.UserRequest;
 import com.shake_match.alchomist.users.dto.response.UserBookmarkResponse;
 import com.shake_match.alchomist.users.dto.response.UserDetailResponse;
 import com.shake_match.alchomist.users.dto.response.UserNicknameResponse;
@@ -14,7 +13,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
-import org.springframework.stereotype.Controller;
 
 @Component
 public class UserConverter {

--- a/src/main/java/com/shake_match/alchomist/users/repository/UserRepository.java
+++ b/src/main/java/com/shake_match/alchomist/users/repository/UserRepository.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-public interface UserRepository extends JpaRepository<Users, java.lang.Long> {
+public interface UserRepository extends JpaRepository<Users, Long> {
 
     Optional<Users> findByNickname(String nickname);
 

--- a/src/main/java/com/shake_match/alchomist/users/service/UserService.java
+++ b/src/main/java/com/shake_match/alchomist/users/service/UserService.java
@@ -14,7 +14,6 @@ import com.shake_match.alchomist.users.Users;
 import com.shake_match.alchomist.users.UsersIngredient;
 import com.shake_match.alchomist.users.converter.UserConverter;
 import com.shake_match.alchomist.users.dto.request.UserBookmarkRequest;
-import com.shake_match.alchomist.users.dto.request.UserRequest;
 import com.shake_match.alchomist.users.dto.request.UserUpdateRequest;
 import com.shake_match.alchomist.users.dto.response.*;
 import com.shake_match.alchomist.users.repository.UserRepository;

--- a/src/main/java/com/shake_match/alchomist/users/service/UserService.java
+++ b/src/main/java/com/shake_match/alchomist/users/service/UserService.java
@@ -1,6 +1,9 @@
 package com.shake_match.alchomist.users.service;
 
 import com.shake_match.alchomist.cocktail.domain.Cocktail;
+import com.shake_match.alchomist.cocktail.domain.CocktailIngredient;
+import com.shake_match.alchomist.cocktail.dto.CocktailSimpleListResponse;
+import com.shake_match.alchomist.cocktail.dto.CocktailSimpleResponse;
 import com.shake_match.alchomist.cocktail.repository.CocktailRepository;
 import com.shake_match.alchomist.global.ErrorCode;
 import com.shake_match.alchomist.global.NotFoundException;
@@ -19,6 +22,8 @@ import com.shake_match.alchomist.users.dto.response.*;
 import com.shake_match.alchomist.users.repository.UserRepository;
 import com.shake_match.alchomist.users.repository.UserIngredientRepository;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -79,6 +84,25 @@ public class UserService {
                 .map(ingredientConverter::converterIngredientListResponse)
                 .collect(Collectors.toList());
         return ingredientConverter.converterIngredientToListResponse(ingredientListResponseList);
+    }
+
+    @Transactional
+    public CocktailSimpleListResponse getAllCocktailByIngredient(List<Long> ingredientId) {
+        List<CocktailIngredient> cocktailIngredients = cocktailRepository.findAllByIngredients(
+            ingredientId);
+
+        Map<Long, Cocktail> map = new HashMap<>();
+        for (CocktailIngredient cocktailIngredient : cocktailIngredients) {
+            Long key = cocktailIngredient.getCocktail().getId();
+            if (!map.containsKey(key)) {
+                map.put(key, cocktailIngredient.getCocktail());
+            }
+        }
+        List<CocktailSimpleResponse> cocktails = map.values()
+            .stream()
+            .map(CocktailSimpleResponse::new)
+            .collect(Collectors.toList());
+        return new CocktailSimpleListResponse(cocktails);
     }
 
     @Transactional

--- a/src/test/java/com/shake_match/alchomist/ingredient/service/IngredientServiceTest.java
+++ b/src/test/java/com/shake_match/alchomist/ingredient/service/IngredientServiceTest.java
@@ -83,7 +83,6 @@ class IngredientServiceTest {
     public void insertTest() {
         List<Ingredient> ingredientList = ingredientRepository.findAll();
         assertThat(ingredientList.size()).isEqualTo(1); // 재료 1개
-        assertThat(ingredientList.get(0).getCocktails().size()).isEqualTo(2); // 재료 1개에 칵테일 2개
     }
 
     @Test


### PR DESCRIPTION
<!-- ❤ chore, docs, feat, fix, refactor, style, test-->
<!-- ❤ [Jira-숫자] test: 유저 CRUD -->
<!-- ❤ Label을 달아주세요. -->

## 1️⃣ 내용
- 설명:  2번 재료아이디를 검색하면, 2번재료아이디를 가지고있는 칵테일 배열 반환 


## 2️⃣ 참고

# GET user/ingredient 
body에 [ 1 ] 
1번 재료를 가진 칵테일 반환

body에 [ 1, 2 ]
1,2번 재료ID를 가진 칵테일 반환 


단 재료ID와 칵테일ID를 서로 매핑해주는건 아직 미구현 , 임시로 sql 쿼리로 할 예정 
`INSERT INTO cocktail_ingredient (cocktail_id, ingredient_id) values(1, 4);`


![image](https://user-images.githubusercontent.com/36220595/146372106-5bd00067-746a-4377-a333-b2e9cc06d34c.png)
