### PR TITLE
feat: 유저의 술장고 재료추가시 삭제후 새로 추가

### DIFF
--- a/src/main/java/com/shake_match/alchomist/users/UsersIngredient.java
+++ b/src/main/java/com/shake_match/alchomist/users/UsersIngredient.java
@@ -22,7 +22,7 @@ public class UsersIngredient {
     private Long id;
 
     @ManyToOne
-    @JoinColumn(name = "user_id")
+    @JoinColumn(name = "provider_id")
     private Users user;
 
     @ManyToOne

--- a/src/main/java/com/shake_match/alchomist/users/controller/UserController.java
+++ b/src/main/java/com/shake_match/alchomist/users/controller/UserController.java
@@ -78,7 +78,7 @@ public class UserController {
     }
 
     // 내 술장고 재료 조회해서 칵테일 배열로 반환
-    @GetMapping("/ingredient")
+    @PostMapping("/ingredient")
     public ApiResponse<CocktailSimpleListResponse> getAllCocktailByIngredients(
         @RequestBody List<Long> ingredientIds) {
         CocktailSimpleListResponse allCocktailByIngredient = userService.getAllCocktailByIngredient(

--- a/src/main/java/com/shake_match/alchomist/users/repository/UserIngredientRepository.java
+++ b/src/main/java/com/shake_match/alchomist/users/repository/UserIngredientRepository.java
@@ -13,4 +13,8 @@ public interface UserIngredientRepository extends JpaRepository<UsersIngredient,
     @Query("delete from UsersIngredient ui where ui.user.id = :userId"
         + " and ui.ingredient.id in :igs")
     void deleteUsersIdAndIngredientIds(@Param("userId") Long userId, @Param("igs") List<Long> igs);
+
+    @Modifying
+    @Query("delete from UsersIngredient ui where ui.user.id = :userId")
+    void deleteUsersIdAndIngredient(@Param("userId") String userId);
 }

--- a/src/main/java/com/shake_match/alchomist/users/service/UserService.java
+++ b/src/main/java/com/shake_match/alchomist/users/service/UserService.java
@@ -81,6 +81,7 @@ public class UserService {
     public IngredientToListResponse getUserByIngredient(Long id) {
         Users user = userRepository.findByProviderId(id.toString())
             .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXIST_MEMBER));
+
         List<IngredientListResponse> ingredientListResponseList =
             user.getUsersIngredient().stream()
                 .map(UsersIngredient::getIngredient)
@@ -112,6 +113,8 @@ public class UserService {
     public void saveIngredientOfUser(Long userId, List<Long> ingredientIds) {
         Users user = userRepository.findByProviderId(userId.toString())
             .orElseThrow(() -> new NotFoundException(ErrorCode.NOT_EXIST_MEMBER));
+
+        userIngredientRepository.deleteUsersIdAndIngredient(user.getProviderId());
 
         List<UsersIngredient> usersIngredients = ingredientIds.stream()
             .map(ingredientId -> ingredientRepository.getById(ingredientId))


### PR DESCRIPTION
<!-- ❤ chore, docs, feat, fix, refactor, style, test-->
<!-- ❤ [Jira-숫자] test: 유저 CRUD -->
<!-- ❤ Label을 달아주세요. -->

## 1️⃣ 내용
- 설명
1. 다중재료 기반 검색할때 user/ingredients로 body에 배열 [재료id, 재료id ...] 담아서 보내는데, 프론트가 axios 사용하고 있어서 GET요청에는 body가 안 담겨서, POST메소드로 변경 

2. 유저의 술장고 재료 추가 시 해당 유저 술장고 재료 전부 삭제 후, 새로 추가

3. 기본 auto증가 id에서 OAUTH 프로바이드 ID로 사용



## 2️⃣ 참고
